### PR TITLE
Add support for Xenium 1.3 outputs

### DIFF
--- a/bin/process_xenium.py
+++ b/bin/process_xenium.py
@@ -8,7 +8,7 @@ Processes Xenium output
 from __future__ import annotations
 import os
 import fire
-import glob
+import json
 import zarr
 import numpy as np
 import scanpy as sc
@@ -42,17 +42,17 @@ def xenium_to_anndata(
         AnnData: AnnData object created from the xenium output data
     """
 
-    p = Path(path)
+    path = Path(path)
 
-    matrix_file = glob.glob(os.path.join(path, "*cell_feature_matrix.h5"))[0]
-    cells_file = glob.glob(os.path.join(path, "*cells.csv.gz"))[0]
+    matrix_file = os.path.join(path, "cell_feature_matrix.h5")
+    cells_file = os.path.join(path, "cells.csv.gz")
 
     adata = sc.read_10x_h5(matrix_file)
 
-    df = pd.read_csv(cells_file, compression="gzip", index_col="cell_id")
-    df.index = df.index.astype(str)
+    with open(os.path.join(path, "experiment.xenium"),"rt") as f:
+        adata.uns["xenium"] = json.load(f)
 
-    adata.obs = df
+    adata.obs = pd.read_csv(cells_file, compression="gzip", index_col="cell_id")
 
     adata.obsm["X_spatial"] = adata.obs[["x_centroid", "y_centroid"]].to_numpy()
 
@@ -61,7 +61,7 @@ def xenium_to_anndata(
 
     if load_clusters:
         for cluster in [
-            d for d in (p / "analysis" / "clustering").iterdir() if d.is_dir()
+            d for d in (path / "analysis" / "clustering").iterdir() if d.is_dir()
         ]:
             cluster_name = cluster.name.replace("gene_expression_", "")
             cluster_df = pd.read_csv(
@@ -69,30 +69,35 @@ def xenium_to_anndata(
                 index_col="Barcode",
             )
 
-            clusters = cluster_df.reindex(adata.obs.index.astype(int))
-            adata.obs[cluster_name] = pd.Categorical(clusters["Cluster"])
+            clusters = cluster_df.reindex(adata.obs.index, fill_value="Undefined")
+            adata.obs[cluster_name] = pd.Categorical(clusters["Cluster"].astype(str))
 
     if load_embeddings:
         embeddings = [
             ("umap", "2_components"),
-            ("tsne", "2_components"),
             ("pca", "10_components"),
         ]
         for embedding, components in embeddings:
             components_name = (
                 components
-                if (p / "analysis" / embedding / components).exists()
+                if (path / "analysis" / embedding / components).exists()
                 else f"gene_expression_{components}"
             )
             embedding_df = pd.read_csv(
                 os.path.join(
-                    p / "analysis" / embedding / components_name / "projection.csv"
+                    path / "analysis" / embedding / components_name / "projection.csv"
                 ),
                 index_col="Barcode",
             )
 
-            emb = embedding_df.reindex(adata.obs.index.astype(int))
+            emb = embedding_df.reindex(adata.obs.index, fill_value=0)
             adata.obsm[f"X_{embedding}"] = emb.values
+
+    # starting on v1.3 cell_id looks like "aaabinlp-1"
+    # pd.Categorical.codes converts them to int this is done manually at this step
+    # instead of reindex_anndata so we control what matches the label image
+    adata.obs = adata.obs.reset_index()
+    adata.obs.index = pd.Categorical(adata.obs['cell_id']).codes.astype(str)
 
     return adata
 
@@ -140,12 +145,26 @@ def xenium_label(
         resolution (float, optional): Pixel resolution. Defaults to 0.2125.
     """
     if os.path.isdir(path):
-        cells_file = glob.glob(os.path.join(path, "*cells.zarr.zip"))[0]
+        cells_file = os.path.join(path, "cells.zarr.zip")
     else:
         cells_file = path
 
     z = zarr.open(cells_file, "r")
-    ids = z["cell_id"]
+
+    with open(os.path.join(path, "experiment.xenium")) as f:
+        experiment = json.load(f)
+    sw_version = float(experiment['analysis_sw_version'][7:10])
+
+    if sw_version < 1.3:
+        ids = z["cell_id"]
+    else:
+        ids = z["cell_id"][:,0]
+
+    # starting on v1.3 cell_id looks like "aaabinlp-1"
+    # pd.Categorical.codes converts them to int
+    # this is required so the label image matches the h5ad ids
+    ids = pd.Categorical(ids).codes
+
     pols = z["polygon_vertices"][1]
 
     label_img = np.zeros((shape[0], shape[1]), dtype=np.min_scalar_type(max(ids)))


### PR DESCRIPTION
Starting on v1.3 cell_id looks like "aaabinlp-1". Changes needed to re-index cells and match them between modalities (h5ad and label image). `pd.Categorical.codes` was used convert cell_ids to int.